### PR TITLE
fix: return empty match response when base response is undefined.

### DIFF
--- a/packages/skills-gameon-sdk/src/client/skillsGameOnApiClient.ts
+++ b/packages/skills-gameon-sdk/src/client/skillsGameOnApiClient.ts
@@ -542,6 +542,10 @@ export class SkillsGameOnApiClient extends GameOnApiClient {
             getMatchesParams.filterBy
         );
 
+        if (!response) {
+            return { matches: [], playerMatches: [] };
+        }
+
         if (getMatchesParams.tournamentId) {
             if (response.matches) {
                 response.matches = response.matches.filter((item: GetMatchListResponseMatch) => {

--- a/packages/skills-gameon-sdk/test/client/skillsGameOnApiClient.spec.ts
+++ b/packages/skills-gameon-sdk/test/client/skillsGameOnApiClient.spec.ts
@@ -52,7 +52,7 @@ describe('skillsGameOnApiClient', () => {
             sinon.restore();
         });
 
-        it('Returns original response if tournamentId is not speciifed', async () => {
+        it('Returns original response if tournamentId is not specified', async () => {
             sinon.replace(skillsGameOnApiClient, 'getMatchList', sinon.fake.returns(matchListResponse));
             const matchResponsePlayer = await skillsGameOnApiClient.getMatchListForPlayer({ player: {} as Player });
             expect(matchResponsePlayer).to.be.deep.equal(originalMatchListResponse);
@@ -90,6 +90,16 @@ describe('skillsGameOnApiClient', () => {
                 tournamentId
             });
             expect(matchResponsePlayer).to.be.deep.equal(originalMatchListResponse);
+        });
+
+        it('Returns no matches if response is undefined', async () => {
+            sinon.replace(skillsGameOnApiClient, 'getMatchList', sinon.fake.returns(undefined));
+            const matchResponsePlayer = await skillsGameOnApiClient.getMatchListForPlayer({
+                player: {} as Player,
+                tournamentId: 'not-a-match'
+            });
+            expect(matchResponsePlayer.matches).to.be.empty;
+            expect(matchResponsePlayer.playerMatches).to.be.empty;
         });
 
     });


### PR DESCRIPTION
If the gameOn API returns an empty body in the getMatchListForPlayer call, the SDK needs to handle it.

https://github.com/alexa-games/skills-gameon-sdk-js/issues/11

# Title

Error getting list of matches for player

## Description

When a user has entered a tournament and is then removed, the GetMatchList call returns an empty response body. This fix handles the empty response body, and returns empty arrays for eligible matches on the getMatchListForPlayer response.

## Issue link(s) - Optional

https://github.com/alexa-games/skills-gameon-sdk-js/issues/11

## Testing

Added a unit test for undefined response.

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License

<!--- This Skills GameOn SDK for Node.js is released under the [Apache License, Version 2.0][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa-games/skills-gameon-sdk-js/issues
[license]: https://www.apache.org/licenses/LICENSE-2.0
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
