### PR TITLE
chore: pin dependency versions

### DIFF
--- a/packages/gameon-sdk/package.json
+++ b/packages/gameon-sdk/package.json
@@ -48,20 +48,20 @@
     "test:coverage": "npx nyc mocha --require ts-node/register test/**/*.spec.ts"
   },
   "devDependencies": {
-    "@types/chai": "^4.1.7",
-    "@types/mocha": "^5.2.6",
-    "@types/nock": "^9.3.1",
-    "@types/sinon": "^7.0.6",
-    "chai": "^4.2.0",
-    "mocha": "^6.0.1",
-    "nock": "^10.0.6",
-    "nyc": "^13.3.0",
-    "sinon": "^7.2.4",
-    "source-map-support": "^0.5.10",
-    "ts-node": "^8.0.2",
-    "tsconfig-paths": "^3.8.0",
-    "tslint": "^5.12.1",
-    "typedoc": "^0.14.2",
-    "typescript": "^3.3.3333"
+    "@types/chai": "4.2.0",
+    "@types/mocha": "5.2.7",
+    "@types/nock": "9.3.1",
+    "@types/sinon": "7.0.13",
+    "chai": "4.2.0",
+    "mocha": "6.2.0",
+    "nock": "10.0.6",
+    "nyc": "13.3.0",
+    "sinon": "7.4.1",
+    "source-map-support": "0.5.13",
+    "ts-node": "8.3.0",
+    "tsconfig-paths": "3.8.0",
+    "tslint": "5.19.0",
+    "typedoc": "0.14.2",
+    "typescript": "3.3.3333"
   }
 }

--- a/packages/skills-gameon-sdk/package.json
+++ b/packages/skills-gameon-sdk/package.json
@@ -59,24 +59,24 @@
   },
   "dependencies": {
     "@alexa-games/gameon-sdk": "^0.0.1",
-    "aws-sdk": "^2.404.0",
-    "ordinal": "^1.0.2",
-    "random-words": "^1.1.0",
-    "uuid": "^3.3.2"
+    "aws-sdk": "2.519.0",
+    "ordinal": "1.0.3",
+    "random-words": "1.1.0",
+    "uuid": "3.3.3"
   },
   "devDependencies": {
-    "@types/chai": "^4.1.7",
-    "@types/mocha": "^5.2.6",
-    "@types/sinon": "^7.0.6",
-    "@types/uuid": "^3.4.4",
-    "chai": "^4.2.0",
-    "mocha": "^6.0.1",
-    "nyc": "^13.3.0",
-    "sinon": "^7.2.4",
-    "source-map-support": "^0.5.10",
-    "ts-node": "^8.0.2",
-    "tsconfig-paths": "^3.8.0",
-    "tslint": "^5.12.1",
-    "typescript": "^3.3.3333"
+    "@types/chai": "4.2.0",
+    "@types/mocha": "5.2.7",
+    "@types/sinon": "7.0.13",
+    "@types/uuid": "3.4.5",
+    "chai": "4.2.0",
+    "mocha": "6.2.0",
+    "nyc": "13.3.0",
+    "sinon": "7.4.1",
+    "source-map-support": "0.5.13",
+    "ts-node": "8.3.0",
+    "tsconfig-paths": "3.8.0",
+    "tslint": "5.19.0",
+    "typescript": "3.3.3333"
   }
 }

--- a/samples/word-word-lite/package.json
+++ b/samples/word-word-lite/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@alexa-games/skills-gameon-sdk": "^0.1.0",
-    "ask-sdk": "^2.0.0"
+    "ask-sdk": "2.519.0"
   },
   "devDependencies": {
     "eslint": "^6.0.1"


### PR DESCRIPTION
# Title

Updated package files to have current versions of dependencies pinned

## Description

Typescript update caused build to fail.
Best practice is to keep dependencies pinned.

## Testing

Ran standard build

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License

<!--- This Skills GameOn SDK for Node.js is released under the [Apache License, Version 2.0][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa-games/skills-gameon-sdk-js/issues
[license]: https://www.apache.org/licenses/LICENSE-2.0
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
