### PR TITLE
Be able to override the native http/https library on the DefaultApiClient

### DIFF
--- a/packages/gameon-sdk/src/client/http/defaultApiClient.ts
+++ b/packages/gameon-sdk/src/client/http/defaultApiClient.ts
@@ -14,6 +14,16 @@ import { ApiClient, ApiClientRequest, ApiClientResponse } from './apiClient';
  * Default implementation of {@link ApiClient} which uses the native HTTP/HTTPS library of Node.JS.
  */
 export class DefaultApiClient implements ApiClient {
+    private httpClient: any;
+    private httpsClient: any;
+
+    constructor(
+        httpClient = require('http'),
+        httpsClient = require('https')
+    ) {
+        this.httpClient = httpClient;
+        this.httpsClient = httpsClient;
+    }
     /**
      * Dispatches a request to an API endpoint described in the request.
      * An ApiClient is expected to resolve the Promise in the case an API returns a non-200 HTTP
@@ -36,7 +46,7 @@ export class DefaultApiClient implements ApiClient {
             method : request.method
         };
 
-        const client = clientRequestOptions.protocol === 'https:' ? require('https') : require('http');
+        const client = clientRequestOptions.protocol === 'https:' ? this.httpsClient : this.httpClient;
 
         return new Promise<ApiClientResponse>((resolve, reject) => {
             const clientRequest = client.request(clientRequestOptions, (response) => {


### PR DESCRIPTION
# Title

This change allows the possibility to override the native http/https library on the DefaultApiClient.

## Motivation and Context

Why would you like to do that? In my case, I'd like to trace the HTTP calls with X-Ray. In order to do so, I need to pass an instrumented version of HTTP library.

I could create a custom ApiClient but then I'd need to copy/paste a lot of code for just a simple change.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License

<!--- This Skills GameOn SDK for Node.js is released under the [Apache License, Version 2.0][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa-games/skills-gameon-sdk-js/issues
[license]: https://www.apache.org/licenses/LICENSE-2.0
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
