### PR TITLE
feat: Multiple Languages leaderboard view

### DIFF
--- a/packages/skills-gameon-sdk/src/utils/displayUtils.ts
+++ b/packages/skills-gameon-sdk/src/utils/displayUtils.ts
@@ -58,7 +58,7 @@ interface RenderOptions {
     scorePrimaryText?: string;
 
     /**
-     * Leaderboard score primary text, default to `You placed ${player.score.ordinalRank}!` if not supplied
+     * Leaderboard score secondary text, default to `${player.score.score} points` if not supplied
      */
     scoreSecondaryText?: string;
 }

--- a/packages/skills-gameon-sdk/src/utils/displayUtils.ts
+++ b/packages/skills-gameon-sdk/src/utils/displayUtils.ts
@@ -53,12 +53,12 @@ interface RenderOptions {
     secondaryColor?: string;
 
     /**
-     * Leaderboard score primary text, default to `You placed ${player.score.ordinalRank}!` if not supplied
+     * Leaderboard score primary text. Will default to `You placed ${player.score.ordinalRank}!` if not supplied
      */
     scorePrimaryText?: string;
 
     /**
-     * Leaderboard score secondary text, default to `${player.score.score} points` if not supplied
+     * Leaderboard score secondary text. Will default to `${player.score.score} points` if not supplied
      */
     scoreSecondaryText?: string;
 }

--- a/packages/skills-gameon-sdk/src/utils/displayUtils.ts
+++ b/packages/skills-gameon-sdk/src/utils/displayUtils.ts
@@ -52,6 +52,15 @@ interface RenderOptions {
      */
     secondaryColor?: string;
 
+    /**
+     * Leaderboard score primary text, default to `You placed ${player.score.ordinalRank}!` if not supplied
+     */
+    scorePrimaryText?: string;
+
+    /**
+     * Leaderboard score primary text, default to `You placed ${player.score.ordinalRank}!` if not supplied
+     */
+    scoreSecondaryText?: string;
 }
 
 /**
@@ -87,6 +96,12 @@ export function renderLeaderboard(player: AugmentedPlayer,
     }
     if (!renderOptions.secondaryColor) {
         renderOptions.secondaryColor = '#66298f';
+    }
+    if (!renderOptions.scorePrimaryText) {
+        renderOptions.scorePrimaryText = `You placed ${player.score.ordinalRank}!`;
+    }
+    if (!renderOptions.scoreSecondaryText) {
+        renderOptions.scoreSecondaryText = `${player.score.score} points`;
     }
 
     return {

--- a/packages/skills-gameon-sdk/src/utils/views/player-rank.json
+++ b/packages/skills-gameon-sdk/src/utils/views/player-rank.json
@@ -253,7 +253,7 @@
                       "paddingLeft": "40dp",
                       "paddingTop": "0",
                       "textAlignVertical": "top",
-                      "text": "You placed ${payload.data.player.score.ordinalRank}!"
+                      "text": "${payload.data.renderOptions.scorePrimaryText}"
                     },
                     {
                       "type": "Text",
@@ -264,7 +264,7 @@
                       "paddingLeft": "40dp",
                       "paddingTop": "0",
                       "textAlignVertical": "bottom",
-                      "text": "${payload.data.player.score.score} points"
+                      "text": "${payload.data.renderOptions.scoreSecondaryText}"
                     }
                   ]
                 }

--- a/packages/skills-gameon-sdk/test/utils/displayUtils.spec.ts
+++ b/packages/skills-gameon-sdk/test/utils/displayUtils.spec.ts
@@ -109,7 +109,7 @@ describe('displayUtils', () => {
             }];
             const leaderboardApl = renderLeaderboard(player, combinationLeaderboard, renderOptions, generator);
             expect(leaderboardApl.datasources.data.player).to.eq(player);
-            expect(leaderboardApl.datasources.data.renderOptions).to.deep.eq(renderOptions);
+            expect(leaderboardApl.datasources.data.renderOptions).to.eq(renderOptions);
             expect(leaderboardApl.datasources.data.renderOptions.scorePrimaryText).to.eq(`You placed ${player.score.ordinalRank}!`);
             expect(leaderboardApl.datasources.data.renderOptions.scoreSecondaryText).to.eq(`${player.score.score} points`);
             expect(leaderboardApl.datasources.data.leaderboard).to.deep.eq(expectedLeaderboard);

--- a/packages/skills-gameon-sdk/test/utils/displayUtils.spec.ts
+++ b/packages/skills-gameon-sdk/test/utils/displayUtils.spec.ts
@@ -373,8 +373,8 @@ describe('displayUtils', () => {
             expect(leaderboardApl.datasources.data.leaderboard).to.deep.eq(expectedLeaderboard);
         });
 
-        it('Single player leaderboard with custom Leaderbaord text', async () => {
-            const scorePrimaryText = 'You are on top 1%';
+        it('Single player leaderboard with custom Leaderboard text', async () => {
+            const scorePrimaryText = 'You are in the top 1%';
             const scoreSecondaryText = '8 stars';
 
             const updatedTextRenderOption = {

--- a/packages/skills-gameon-sdk/test/utils/displayUtils.spec.ts
+++ b/packages/skills-gameon-sdk/test/utils/displayUtils.spec.ts
@@ -109,7 +109,9 @@ describe('displayUtils', () => {
             }];
             const leaderboardApl = renderLeaderboard(player, combinationLeaderboard, renderOptions, generator);
             expect(leaderboardApl.datasources.data.player).to.eq(player);
-            expect(leaderboardApl.datasources.data.renderOptions).to.eq(renderOptions);
+            expect(leaderboardApl.datasources.data.renderOptions).to.deep.eq(renderOptions);
+            expect(leaderboardApl.datasources.data.renderOptions.scorePrimaryText).to.eq(`You placed ${player.score.ordinalRank}!`);
+            expect(leaderboardApl.datasources.data.renderOptions.scoreSecondaryText).to.eq(`${player.score.score} points`);
             expect(leaderboardApl.datasources.data.leaderboard).to.deep.eq(expectedLeaderboard);
         });
 
@@ -370,6 +372,51 @@ describe('displayUtils', () => {
             expect(leaderboardApl.datasources.data.renderOptions).to.eq(renderOptions);
             expect(leaderboardApl.datasources.data.leaderboard).to.deep.eq(expectedLeaderboard);
         });
+
+        it('Single player leaderboard with custom Leaderbaord text', async () => {
+            const scorePrimaryText = 'You are on top 1%';
+            const scoreSecondaryText = '8 stars';
+
+            const updatedTextRenderOption = {
+                ...renderOptions,
+                scorePrimaryText,
+                scoreSecondaryText
+            };
+
+            const player = {
+                score: {
+                    rank: 1,
+                    score: 22,
+                    ordinalRank: '1st'
+                },
+                profile: {
+                    name: 'Patiently Plain Lynx',
+                    avatar: '/37.png',
+                    color: 'cef2a0'
+                },
+                sessionApiKey: '5155ce02-1111-1111-2222-71882d1a52ad',
+                sessionId: '553c5f49-1111-1111-2222-fb2e5d43c0b5',
+                sessionExpirationDate: 0,
+                externalPlayerId: 'a99c89bd-1111-1111-2222-671b012cd1c4',
+                playerToken: '0774aba7-1111-1111-2222-c2355aebf8c8'
+            } as AugmentedPlayer;
+
+            const combinationLeaderboard = {
+                topNLeaderboard: [
+                    {
+                        externalPlayerId: player.externalPlayerId,
+                        score: player.score.score,
+                        rank: player.score.rank
+                    }
+                ],
+                neighborLeaderboard: []
+            } as CombinationLeaderboard;
+
+            const leaderboardApl = renderLeaderboard(player, combinationLeaderboard, updatedTextRenderOption, generator);
+            expect(leaderboardApl.datasources.data.renderOptions.scorePrimaryText).to.eq(scorePrimaryText);
+            expect(leaderboardApl.datasources.data.renderOptions.scoreSecondaryText).to.eq(scoreSecondaryText);
+        });
+
     });
 
 });


### PR DESCRIPTION
# Title

Multiple Languages leaderboard

## Description

Currently, the APL for displaying leaderboard is in English only. I'm making the fields customizable, to overwrite for different languages

## Motivation and Context

I would like to use .renderLeaderboard for languages other than English

## Testing

`scorePrimaryText` and `scoreSecondaryText` can be set to change APL

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License

- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa-games/skills-gameon-sdk-js/issues
[license]: https://www.apache.org/licenses/LICENSE-2.0
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
